### PR TITLE
Adds a container for DynamoDB local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ It builds an image with Ruby 2.2.0 installed, compliled from source. It also ins
 shared-storage
 --------------
 It builds a minimal (~2MB) image based on busybox that creates a volume in /data. It's purpose is to serve as a shared volume across related containers.
+
+dynamodb
+--------
+Builds an image for local dynamodb development

--- a/dynamodb/Dockerfile
+++ b/dynamodb/Dockerfile
@@ -1,0 +1,12 @@
+FROM centos:centos7
+MAINTAINER Marcos Hernandez "marcos.hernandez@gmail.com"
+ENV REFRESHED_AT 2015-01-04
+RUN yum -y update
+RUN yum install -y tar java
+RUN yum clean all
+ADD http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest.tar.gz /opt/dynamodb/
+WORKDIR /opt/dynamodb
+RUN tar -xzf dynamodb_local_latest.tar.gz
+RUN rm dynamodb_local_latest.tar.gz
+EXPOSE 8000
+ENTRYPOINT java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar


### PR DESCRIPTION
Testing my Docker super-powers before Real Madrid' match
- DynamoDB local development image
- Can be optimized joining RUN commands to avoid extra image generation
- Maybe local database should shared using a VOLUME
- CMD could be used to pass parameters and override options (maybe to force InMemory DynamoDB)

Keep going.
